### PR TITLE
Determine wrap column based on file rulers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,19 @@
 {
     "name": "vs-code-paragraph-hard-wrapper",
-    "displayName": "Paragraph hard wrapper",
+    "displayName": "Paragraph Hard Wrapper",
     "description": "Replicates Sublime Text Alt + Q command on VS Code",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "publisher": "haapanen",
     "engines": {
-        "vscode": "^1.0.0"
+        "vscode": "^1.29.0"
     },
     "categories": [
         "Other"
     ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/haapanen/vs-code-paragraph-hard-wrapper"
+    },
     "activationEvents": [
         "onCommand:paragraphHardWrapper.wrap"
     ],
@@ -18,15 +22,31 @@
         "commands": [{
             "command": "paragraphHardWrapper.wrap",
             "title": "Hard Wrap"
-        }]
+        }],
+        "configuration": {
+            "title": "Paragraph Hard Wrapper",
+            "properties": {
+                "paragraphHardWrapper.defaultWrapColumn": {
+                    "type": "number",
+                    "default": 80,
+                    "description": "Paragraph wrap column if no rulers are present"
+                }
+            }
+        }
     },
     "scripts": {
-        "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-        "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+        "vscode:prepublish": "tsc -p ./",
+        "compile": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "devDependencies": {
-        "typescript": "^1.8.5",
-        "vscode": "^0.11.0"
+        "typescript": "^2.0.3",
+        "vscode": "^1.0.0",
+        "mocha": "^2.3.3",
+        "@types/node": "^6.0.40",
+        "@types/mocha": "^2.2.32"
+    },
+    "dependencies": {
+        "vsce": "1.69.0"
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,11 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "outDir": "out",
-        "noLib": true,
+        "lib": [
+            "es6"
+        ],
         "sourceMap": true,
         "rootDir": "."
     },

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/node.d.ts" />

--- a/typings/vscode-typings.d.ts
+++ b/typings/vscode-typings.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/index.d.ts" />


### PR DESCRIPTION
- Determine smallest file ruler, and use a wrap column
- Add configurable default column if no rulers
- Do not leave whitespace at end of lines
- Update VSCode and typescript versions
- Update to version 0.0.2